### PR TITLE
fixed a minor bug in useLocalStorage hook

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -6,7 +6,7 @@ const getLocalValue = (key, initValue) => {
 
     // if a value is already store 
     const localValue = JSON.parse(localStorage.getItem(key));
-    if (localValue) return localValue;
+    if (localValue != undefined) return localValue;
 
     // return result of a function 
     if (initValue instanceof Function) return initValue();


### PR DESCRIPTION
when you are fetching localValue from local storage you are checking `if (localValue)` but it can also be a **boolean** value with false stored in it, then it will reject it and return the default initValue. So I replaced it with `if (localValue != undefined)`