### PR TITLE
Fix "undefined is not valid JSON" error

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -5,8 +5,8 @@ const getLocalValue = (key, initValue) => {
     if (typeof window === 'undefined') return initValue;
 
     // if a value is already store 
-    const localValue = JSON.parse(localStorage.getItem(key));
-    if (localValue) return localValue;
+    const localValue = localStorage.getItem(key);
+    if (localValue && localValue !== 'undefined') return JSON.parse(localValue);
 
     // return result of a function 
     if (initValue instanceof Function) return initValue();


### PR DESCRIPTION
This fix addresses the JSON.parse() error when the localStorage.getItem(key) returns 'undefined'